### PR TITLE
fix subobject-linkage warnings

### DIFF
--- a/include/kmer.hpp
+++ b/include/kmer.hpp
@@ -109,9 +109,9 @@ struct alpha_kmer_t : uint_kmer_t<Kmer, BitsPerChar> {
 };
 
 #ifdef SSHASH_USE_TRADITIONAL_NUCLEOTIDE_ENCODING
-constexpr char nucleotides[] = "ACGT";
+inline constexpr char nucleotides[] = "ACGT";
 #else
-constexpr char nucleotides[] = "ACTG";
+inline constexpr char nucleotides[] = "ACTG";
 #endif
 
 template <typename Kmer>


### PR DESCRIPTION
This fixes a warning caused by this issue:
https://stackoverflow.com/questions/72801432/why-do-i-get-the-child-has-a-base-whose-type-uses-the-anonymous-namespace-warn

It seems like having a pointer as a template argument is problematic unless it's inline.