### PR TITLE
fix warning when printing uint128_t

### DIFF
--- a/test/test_alphabet.cpp
+++ b/test/test_alphabet.cpp
@@ -5,8 +5,7 @@
 using namespace sshash;
 
 std::ostream& operator<<(std::ostream& os, __uint128_t x) {
-    const uint64_t *xp = reinterpret_cast<uint64_t*>(&x);
-    os << xp[0] << xp[1];
+    os << static_cast<uint64_t>(x) << static_cast<uint64_t>(x >> 64);
     return os;
 }
 

--- a/test/test_alphabet.cpp
+++ b/test/test_alphabet.cpp
@@ -5,8 +5,8 @@
 using namespace sshash;
 
 std::ostream& operator<<(std::ostream& os, __uint128_t x) {
-    os << *(reinterpret_cast<uint64_t*>(&x) + 0);
-    os << *(reinterpret_cast<uint64_t*>(&x) + 1);
+    const uint64_t *xp = reinterpret_cast<uint64_t*>(&x);
+    os << xp[0] << xp[1];
     return os;
 }
 


### PR DESCRIPTION
This should fix the following compile warning:
```
sshash/test/test_alphabet.cpp:8:45: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    8 |     os << *(reinterpret_cast<uint64_t*>(&x) + 0);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```